### PR TITLE
Drive motor unit conversion fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2024.1.1"
+    id "edu.wpi.first.GradleRIO" version "2024.2.1"
 }
 
 java {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -66,16 +66,18 @@ public final class Constants {
 
     public static final boolean kGyroReversed = false;
 
+    // Note that SwerveModuleConstants.kMaxSpeedMedersPerSecond may saturate if this is set too high, in combination with
+    // SwerveModuleConstants.kMaxAngularSpeedRadiansPerSecond.
     public static final double kMaxSpeedMetersPerSecond = 5.0;
   }
 
   public static final class SwerveModuleConstants {
-    public static final double kMaxAngularSpeedRadiansPerSecond = 2 * Math.PI;
-    public static final double kMaxAngularAccelerationRadiansPerSecondSquared = 4 * Math.PI;
+    public static final double kMaxAngularSpeedRadiansPerSecond = 3.0 * Math.PI;
+    public static final double kMaxAngularAccelerationRadiansPerSecondSquared = 1.5 * Math.PI;
 
-    public static final double kMaxSpeedMetersPerSecond = DriveConstants.kMaxSpeedMetersPerSecond;
-    public static final double kMaxAccelerationMetersPerSecond = 7.5;
-    public static final double kMaxDecelerationMetersPerSecond = 15.0;
+    public static final double kMaxSpeedMetersPerSecond = DriveConstants.kMaxSpeedMetersPerSecond * 2.0;
+    public static final double kMaxAccelerationMetersPerSecondSquared = 7.5;
+    public static final double kMaxDecelerationMetersPerSecondSquared = 15.0;
 
     public static final double kAbsoluteEncoderCPR = 4096.0;
     public static final double kWheelDiameterMeters = 0.09525;
@@ -90,10 +92,11 @@ public final class Constants {
     public static final double kIDriveController = 0.0;
     public static final double kDDriveController = 0.0;
 
+
     public static final TrapezoidalConstraint kVelocityProfile = new TrapezoidalConstraint(
       kMaxSpeedMetersPerSecond,
-      kMaxAccelerationMetersPerSecond,
-      kMaxDecelerationMetersPerSecond
+      kMaxAccelerationMetersPerSecondSquared,
+      kMaxDecelerationMetersPerSecondSquared
     );
   }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -75,6 +75,7 @@ public final class Constants {
 
     public static final double kMaxSpeedMetersPerSecond = DriveConstants.kMaxSpeedMetersPerSecond;
     public static final double kMaxAccelerationMetersPerSecond = 7.5;
+    public static final double kMaxDecelerationMetersPerSecond = 15.0;
 
     public static final double kAbsoluteEncoderCPR = 4096.0;
     public static final double kWheelDiameterMeters = 0.09525;
@@ -91,7 +92,8 @@ public final class Constants {
 
     public static final TrapezoidalConstraint kVelocityProfile = new TrapezoidalConstraint(
       kMaxSpeedMetersPerSecond,
-      kMaxAccelerationMetersPerSecond
+      kMaxAccelerationMetersPerSecond,
+      kMaxDecelerationMetersPerSecond
     );
   }
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -66,7 +66,7 @@ public final class Constants {
 
     public static final boolean kGyroReversed = false;
 
-    public static final double kMaxSpeedMetersPerSecond = 0.5;
+    public static final double kMaxSpeedMetersPerSecond = 5.0;
   }
 
   public static final class SwerveModuleConstants {
@@ -76,26 +76,22 @@ public final class Constants {
     public static final double kMaxSpeedMetersPerSecond = DriveConstants.kMaxSpeedMetersPerSecond;
     public static final double kMaxAccelerationMetersPerSecond = 7.5;
 
-    public static final double kDriveEncoderCPR = 42.0;
     public static final double kAbsoluteEncoderCPR = 4096.0;
     public static final double kWheelDiameterMeters = 0.09525;
 
     public static final double kDriveGearRatio = 6.75;
 
-    public static final double kDriveEncoderDistancePerPulse =
-        (kWheelDiameterMeters * Math.PI) / (kDriveEncoderCPR * kDriveGearRatio);
-
-    public static final double kPTurningController = 0.2;
+    public static final double kPTurningController = 0.5;
     public static final double kITurningController = 0.0;
     public static final double kDTurningController = 0.0;
 
-    public static final double kPDriveController = 0.01;
+    public static final double kPDriveController = 0.5;
     public static final double kIDriveController = 0.0;
     public static final double kDDriveController = 0.0;
 
     public static final TrapezoidalConstraint kVelocityProfile = new TrapezoidalConstraint(
-      kMaxSpeedMetersPerSecond / (kDriveEncoderDistancePerPulse),
-      kMaxAccelerationMetersPerSecond / (kDriveEncoderDistancePerPulse)
+      kMaxSpeedMetersPerSecond,
+      kMaxAccelerationMetersPerSecond
     );
   }
 

--- a/src/main/java/frc/robot/TrapezoidalConstraint.java
+++ b/src/main/java/frc/robot/TrapezoidalConstraint.java
@@ -5,14 +5,19 @@ import edu.wpi.first.math.MathUtil;
 public class TrapezoidalConstraint {
     private final double m_maxSpeed;
     private final double m_maxAcceleration;
+    private final double m_maxDeceleration;
 
-    public TrapezoidalConstraint(double maxSpeed, double maxAcceleration) {
+    public TrapezoidalConstraint(double maxSpeed, double maxAcceleration, double maxDeceleration) {
+        assert(maxSpeed >= 0.0);
+        assert(maxAcceleration >= 0.0);
+        assert(maxDeceleration >= 0.0); // We negate this during calculation.
         m_maxSpeed = maxSpeed;
         m_maxAcceleration = maxAcceleration;
+        m_maxDeceleration = maxDeceleration;
     }
 
     public double calculate(double desiredVelocity, double currentVelocity, double deltaT) {
-        double acceleration = MathUtil.clamp((desiredVelocity - currentVelocity) / deltaT, -m_maxAcceleration, m_maxAcceleration);
+        double acceleration = MathUtil.clamp((desiredVelocity - currentVelocity) / deltaT, -m_maxDeceleration, m_maxAcceleration);
         double deltaV = acceleration * deltaT;
         double newVelocity = currentVelocity + deltaV;
         return MathUtil.clamp(newVelocity, -m_maxSpeed, m_maxSpeed);

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -4,7 +4,6 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix6.mechanisms.swerve.SimSwerveDrivetrain.SimSwerveModule;
 import com.kauailabs.navx.frc.AHRS;
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
@@ -19,7 +18,6 @@ import edu.wpi.first.math.kinematics.SwerveDriveOdometry;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
 import edu.wpi.first.wpilibj.SPI;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.Constants;
 import frc.robot.Constants.DriveConstants;
@@ -118,7 +116,6 @@ private final SwerveModule m_frontRight = //Q4
         getRotation2d(),
         getPositions()
         );
-        SmartDashboard.putNumber(("Yaw"), getYaw());
   }
 
   /**
@@ -181,13 +178,12 @@ private final SwerveModule m_frontRight = //Q4
    */
   @SuppressWarnings("ParameterName")
   public void drive(double xSpeed, double ySpeed, double rot, boolean fieldRelative) {
+    ChassisSpeeds chassisSpeeds = fieldRelative
+      ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, getRotation2d())
+      : new ChassisSpeeds(xSpeed, ySpeed, rot);
     var swerveModuleStates =
         DriveConstants.kDriveKinematics.toSwerveModuleStates(
-          ChassisSpeeds.discretize(
-            fieldRelative
-              ? ChassisSpeeds.fromFieldRelativeSpeeds(xSpeed, ySpeed, rot, getRotation2d())
-              : new ChassisSpeeds(xSpeed, ySpeed, rot)
-            , Constants.kDt));
+          ChassisSpeeds.discretize(chassisSpeeds, Constants.kDt));
 
     setModuleStates(swerveModuleStates);
   }
@@ -206,7 +202,7 @@ private final SwerveModule m_frontRight = //Q4
    */
   public void setModuleStates(SwerveModuleState[] desiredStates) {
     SwerveDriveKinematics.desaturateWheelSpeeds(
-        desiredStates, DriveConstants.kMaxSpeedMetersPerSecond);
+        desiredStates, Constants.SwerveModuleConstants.kMaxSpeedMetersPerSecond);
     m_frontLeft.setDesiredState(desiredStates[0]); //Q1
     m_rearLeft.setDesiredState(desiredStates[1]); //Q2
     m_rearRight.setDesiredState(desiredStates[2]); //Q3


### PR DESCRIPTION
I connected to a drive motor with the REV hardware client and determined that position is reported in rotations rather than encoder ticks (counts). Eventually I found the documentation for the "native units" used by the SPARK MAX -- position is revolutions, and velocity is rotations per minute ("RPM").

On the bright side, this is a lot simpler to work with than what we had to do with the Phoenix API, but we had numerous conversion bugs, some partially canceling each other out. Anyway, I actually tested this on Thor, verifying that odometry matches reality within a few percent (estimated without tape measure, just drove the full length of the field). There are lots of things to tune still, such as the twitchy rotation, but this pull request restores us to behavior similar to what we had with Falcon motors.