### PR TITLE
Vision

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -212,14 +212,10 @@ public final class Constants {
     public static final String kCameraName1 = "camera1";
     public static final String kCameraName2 = "camera2";
     public static final Transform3d kRobotToCamera1Transform = new Transform3d(
-      Units.inchesToMeters(10.75),
-      Units.inchesToMeters(-2.25),
-      Units.inchesToMeters(11.125),
-      new Rotation3d(0.0, Units.degreesToRadians(-19.5), Units.degreesToRadians(0)));
+      0.273, -0.057, 0.283,
+      new Rotation3d(0.0, Units.degreesToRadians(-19.5), 0.0));
     public static final Transform3d kRobotToCamera2Transform = new Transform3d(
-      Units.inchesToMeters(7.5),
-      Units.inchesToMeters(0.625),
-      Units.inchesToMeters(14.0),
-      new Rotation3d(Units.degreesToRadians(-21.9), Units.degreesToRadians(0.0), Units.degreesToRadians(90)));
+      0.191, 0.016, 0.356,
+      new Rotation3d(Units.degreesToRadians(-21.9), 0.0, Units.degreesToRadians(100.0)));
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -211,15 +211,15 @@ public final class Constants {
   public static class PhotonVisionConstants {
     public static final String kCameraName1 = "camera1";
     public static final String kCameraName2 = "camera2";
-    public static final Transform3d kCamera1ToRobotOffset = new Transform3d(
-      Units.inchesToMeters(-10.75), 
-      Units.inchesToMeters(2.25), 
-      Units.inchesToMeters(-11.125), 
-      new Rotation3d(0.0, Units.degreesToRadians(19.5), Units.degreesToRadians(0)));
-    public static final Transform3d kCamera2ToRobotOffset = new Transform3d(
-      Units.inchesToMeters(-7.5), 
-      Units.inchesToMeters(.625), 
-      Units.inchesToMeters(-14), 
-      new Rotation3d(0.0, Units.degreesToRadians(21.9), Units.degreesToRadians(90)));
+    public static final Transform3d kRobotToCamera1Transform = new Transform3d(
+      Units.inchesToMeters(10.75),
+      Units.inchesToMeters(-2.25),
+      Units.inchesToMeters(11.125),
+      new Rotation3d(0.0, Units.degreesToRadians(-19.5), Units.degreesToRadians(0)));
+    public static final Transform3d kRobotToCamera2Transform = new Transform3d(
+      Units.inchesToMeters(7.5),
+      Units.inchesToMeters(0.625),
+      Units.inchesToMeters(14.0),
+      new Rotation3d(Units.degreesToRadians(-21.9), Units.degreesToRadians(0.0), Units.degreesToRadians(90)));
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -64,7 +64,7 @@ public final class Constants {
     public static final double kWheelBase = 0.681; // Distance between front and back wheels on robot
 
     public static final Vector<N3> stateStdDeviations = VecBuilder.fill(0.005, 0.005, Math.toRadians(1));
-    public static final Vector<N3> visionStdDeviations = VecBuilder.fill(0.005, 0.005, Math.toRadians(1));
+    public static final Vector<N3> visionStdDeviations = VecBuilder.fill(0.050, 0.050, Math.toRadians(5));
 
     public static final SwerveDriveKinematics kDriveKinematics =
       new SwerveDriveKinematics(

--- a/src/main/java/frc/robot/subsystems/CameraSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/CameraSubsystem.java
@@ -44,7 +44,7 @@ public class CameraSubsystem extends SubsystemBase {
       m_aprilTagFieldLayout,
       PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
       m_camera1,
-      PhotonVisionConstants.kCamera1ToRobotOffset
+      PhotonVisionConstants.kRobotToCamera1Transform
     );
     
     m_photonPoseEstimatorCam2 =
@@ -52,7 +52,7 @@ public class CameraSubsystem extends SubsystemBase {
       m_aprilTagFieldLayout,
       PoseStrategy.MULTI_TAG_PNP_ON_COPROCESSOR,
       m_camera2,
-      PhotonVisionConstants.kCamera2ToRobotOffset
+      PhotonVisionConstants.kRobotToCamera2Transform
     );
 
     m_photonPoseEstimatorCam1.setTagModel(TargetModel.kAprilTag36h11);
@@ -96,7 +96,7 @@ public class CameraSubsystem extends SubsystemBase {
     return PhotonUtils.estimateFieldToRobotAprilTag(
         target.getBestCameraToTarget(),
         m_aprilTagFieldLayout.getTagPose(target.getFiducialId()).get(),
-        PhotonVisionConstants.kCamera1ToRobotOffset
+        PhotonVisionConstants.kRobotToCamera1Transform
       );
   }
 


### PR DESCRIPTION
This fixes PhotonVision odometry and prepares the way for fine tuning of pose estimate confidence and wheel odometry. Given reasonably accurate vision estimates, we will be able to start at a known location, hide the AprilTag(s), drive some distance, record the current pose estimate, then uncover the AprilTag(s) to converge on the actual location. We can use this as the basis for a compensation factor relative to ideal wheel odometry.